### PR TITLE
[patch] Dim id check fix

### DIFF
--- a/src/main/java/com/github/cfogrady/vb/dim/header/BemHeaderWriter.java
+++ b/src/main/java/com/github/cfogrady/vb/dim/header/BemHeaderWriter.java
@@ -16,7 +16,7 @@ public class BemHeaderWriter {
         relativeOutputStream.writeBytes(headerData.getText().getBytes());
         relativeOutputStream.writeZerosUntilOffset(0x32);
         relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()));
-        relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()));
+        relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()&0xFF));
         relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionYear()));
         relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionMonth()));
         relativeOutputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionDay()));

--- a/src/main/java/com/github/cfogrady/vb/dim/header/DimHeaderReader.java
+++ b/src/main/java/com/github/cfogrady/vb/dim/header/DimHeaderReader.java
@@ -20,8 +20,8 @@ public class DimHeaderReader {
             log.error("Reader only handles data DIMs");
             throw new IllegalArgumentException("Reader only handles data DIMs");
         }
-        if(values[0x32/2] != values[0x34/2]) {
-            log.warn("Presumed DIM Ids {} and {} do not match! Please make an issue with the DIM card in question on https://github.com/cfogrady/DIM-Modifier/issues so I purchase and analyze the card", values[0x32/2], values[0x34/2]);
+        if((values[0x32/2] & 0xFF) != values[0x34/2]) {
+            log.warn("Masked DIM Id {} doesn't match check {}! Please make an issue with the DIM card in question on https://github.com/cfogrady/DIM-Modifier/issues so I purchase and analyze the card", values[0x32/2] & 0xFF, values[0x34/2]);
         }
         return builder
                 .text(new String(Arrays.copyOfRange(bytes, 0x10, 0x30)))

--- a/src/main/java/com/github/cfogrady/vb/dim/header/HeaderWriter.java
+++ b/src/main/java/com/github/cfogrady/vb/dim/header/HeaderWriter.java
@@ -14,7 +14,7 @@ public class HeaderWriter {
         outputStream.writeBytes(headerData.getText().getBytes());
         outputStream.writeZerosUntilOffset(0x32);
         outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()));
-        outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()));
+        outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getDimId()&0xFF));
         outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionYear()));
         outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionMonth()));
         outputStream.writeBytes(ByteUtils.convert16BitIntToBytes(headerData.getProductionDay()));

--- a/src/test/java/com/github/cfogrady/vb/dim/header/BemHeaderReaderTest.java
+++ b/src/test/java/com/github/cfogrady/vb/dim/header/BemHeaderReaderTest.java
@@ -1,5 +1,6 @@
 package com.github.cfogrady.vb.dim.header;
 
+import com.github.cfogrady.vb.dim.util.ByteUtils;
 import com.github.cfogrady.vb.dim.util.RelativeByteOffsetOutputStream;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.Random;
 
 public class BemHeaderReaderTest {
@@ -35,6 +37,16 @@ public class BemHeaderReaderTest {
         Assertions.assertEquals(sampleHeader.getRevisionNumber(), readHeader.getRevisionNumber());
         Assertions.assertArrayEquals(sampleHeader.getSpriteSignature(), readHeader.getSpriteSignature());
         Assertions.assertArrayEquals(sampleHeader.getBemFlags(), readHeader.getBemFlags());
+    }
+
+    @Test
+    void test2ByteDimIdCheckWrittenWithLowerByteOnly() {
+        BemHeader sampleHeader = createSampleHeader().toBuilder().dimId(297).build();
+        byte[] headerBytes = getBytesForHeader(sampleHeader);
+        byte[] dimIdBytes = Arrays.copyOfRange(headerBytes, 0x32, 0x34);
+        byte[] dimIdCheckBytes = Arrays.copyOfRange(headerBytes, 0x34, 0x36);
+        Assertions.assertEquals(sampleHeader.getDimId(), ByteUtils.getUnsigned16Bit(dimIdBytes)[0]);
+        Assertions.assertEquals(sampleHeader.getDimId()&0xFF, ByteUtils.getUnsigned16Bit(dimIdCheckBytes)[0]);
     }
 
     private byte[] createRandomBytes(int size) {

--- a/src/test/java/com/github/cfogrady/vb/dim/header/DimHeaderWriterTest.java
+++ b/src/test/java/com/github/cfogrady/vb/dim/header/DimHeaderWriterTest.java
@@ -1,0 +1,59 @@
+package com.github.cfogrady.vb.dim.header;
+
+import com.github.cfogrady.vb.dim.util.ByteUtils;
+import com.github.cfogrady.vb.dim.util.RelativeByteOffsetOutputStream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Arrays;
+import java.util.Random;
+
+public class DimHeaderWriterTest {
+
+    private static Random random = new Random();
+
+    private byte[] getBytesForHeader(DimHeader header) {
+
+        try(ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            HeaderWriter.writeHeader(header, new RelativeByteOffsetOutputStream(outputStream));
+            return outputStream.toByteArray();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Test
+    void test2ByteDimIdCheckWrittenWithLowerByteOnly() {
+        DimHeader sampleHeader = createSampleHeader().toBuilder().dimId(296).build();
+        byte[] headerBytes = getBytesForHeader(sampleHeader);
+        byte[] dimIdBytes = Arrays.copyOfRange(headerBytes, 0x32, 0x34);
+        byte[] dimIdCheckBytes = Arrays.copyOfRange(headerBytes, 0x34, 0x36);
+        Assertions.assertEquals(sampleHeader.getDimId(), ByteUtils.getUnsigned16Bit(dimIdBytes)[0]);
+        Assertions.assertEquals(sampleHeader.getDimId()&0xFF, ByteUtils.getUnsigned16Bit(dimIdCheckBytes)[0]);
+    }
+
+    private byte[] createRandomBytes(int size) {
+        byte[] bytes = new byte[size];
+        random.nextBytes(bytes);
+        return bytes;
+    }
+
+    private DimHeader createSampleHeader() {
+        String thirtyTwoCharacterString = "cfogrady_0_0_DIM_READER_0_0_0_0_";
+        return DimHeader.builder()
+                .dimId(42)
+                .headerSignature(createRandomBytes(0x60 - 0x40))
+                .has0x8fSet(false)
+                .productionDay(19)
+                .productionMonth(12)
+                .productionYear(22)
+                .revisionNumber(0)
+                .text(thirtyTwoCharacterString)
+                .spriteSignature(createRandomBytes(0x1030-0x1010))
+                .build();
+    }
+}


### PR DESCRIPTION
There is an issue where newer cards (with DIM Ids >255) have a different value written to what I once presumed to just be a copy of DIM Id. It does appear to be a copy, but seems to be only the lower byte of the id.

This change fixes this by recognizing only the lower byte of the dim id check value for reading and writing.